### PR TITLE
5.6迁移5.7时,需要设置该参数

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -153,6 +153,7 @@ show variables like '%max_connections%';
 set GLOBAL innodb_file_format_max = 'Barracuda';
 set GLOBAL innodb_file_format = 'Barracuda';
 set GLOBAL  innodb_file_per_table = ON;
+set GLOBAL innodb_strict_mode = OFF;
 ```
 
 


### PR DESCRIPTION
5.6迁移5.7时，如果出现
```
Row size too large (> 8126). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
```
可以通过在目标库设置该参数解决